### PR TITLE
Fixes for fixIntegrationTests2

### DIFF
--- a/test/ILLink.Tasks.Tests/TestContext.cs
+++ b/test/ILLink.Tasks.Tests/TestContext.cs
@@ -63,7 +63,7 @@ namespace ILLink.Tests
 #else
 			// Tests are run from <root>/bin/ILLink.Tasks.Tests/Debug/netcoreapp3.0
 			string repoRoot = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, "..", "..", "..", ".."));
-			TasksDirectoryRoot = Path.Combine(repoRoot, "bin", "ILLink.Tasks") + Path.DirectorySeparatorChar;
+			TasksDirectoryRoot = Path.Combine(repoRoot, "bin", "ILLink.Tasks", "Debug") + Path.DirectorySeparatorChar;
 #endif
 			if (!Directory.Exists(TasksDirectoryRoot))
 				throw new Exception($"failed to locate local linker tasks at {TasksDirectoryRoot}");

--- a/test/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
+++ b/test/Mono.Linker.Tests.Cases.Expectations/Mono.Linker.Tests.Cases.Expectations.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup Condition=" $(Configuration.StartsWith('illink')) ">
     <TargetFramework>netcoreapp3.0</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition=" ! $(Configuration.StartsWith('illink')) ">
     <TargetFramework>net471</TargetFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
 </Project>

--- a/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
+++ b/test/Mono.Linker.Tests/Mono.Linker.Tests.csproj
@@ -13,6 +13,7 @@
     <IsUnitTestProject>true</IsUnitTestProject>
     <!-- Arcade's custom test imports assume that we are using xunit. -->
     <DisableArcadeTestFramework Condition=" '$(ArcadeBuild)' == 'true' ">true</DisableArcadeTestFramework>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
   <PropertyGroup Condition=" ! $(Configuration.StartsWith('illink')) ">


### PR DESCRIPTION
-Changing TestContext.cs to support "Debug" folder in linker path infrastructure
-Include GenerateAssemblyInfo tag in "false" into 
  Mono.Linker.Test.Cases.Expectations.csproj 
  Mono.Linker.Tests.csproj