### PR TITLE
Don't include new() constraint for generic params with struct constraint when warn=5

### DIFF
--- a/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.RoslynAnalyzer/TrimAnalysis/HandleCallAction.cs
@@ -29,6 +29,7 @@ namespace ILLink.Shared.TrimAnalysis
 			_annotations = FlowAnnotations.Instance;
 			_reflectionAccessAnalyzer = new ReflectionAccessAnalyzer ();
 			_requireDynamicallyAccessedMembersAction = new (diagnosticContext, _reflectionAccessAnalyzer);
+			_warnVersion = WarnVersion.Latest;
 		}
 
 		private partial IEnumerable<SystemReflectionMethodBaseValue> GetMethodsOnTypeHierarchy (TypeProxy type, string name, BindingFlags? bindingFlags)

--- a/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
+++ b/src/ILLink.Shared/TrimAnalysis/HandleCallAction.cs
@@ -26,6 +26,7 @@ namespace ILLink.Shared.TrimAnalysis
 		readonly DiagnosticContext _diagnosticContext;
 		readonly FlowAnnotations _annotations;
 		readonly RequireDynamicallyAccessedMembersAction _requireDynamicallyAccessedMembersAction;
+		readonly WarnVersion _warnVersion;
 
 		public bool Invoke (MethodProxy calledMethod, MultiValue instanceValue, IReadOnlyList<MultiValue> argumentValues, out MultiValue methodReturnValue, out IntrinsicId intrinsicId)
 		{
@@ -1217,6 +1218,7 @@ namespace ILLink.Shared.TrimAnalysis
 
 		bool AnalyzeGenericInstantiationTypeArray (in MultiValue arrayParam, in MethodProxy calledMethod, ImmutableArray<GenericParameterValue> genericParameters)
 		{
+			var warnVersion = _warnVersion; // Get around compiler issue to use _warnVersion in local method
 			bool hasRequirements = false;
 			foreach (var genericParameter in genericParameters) {
 				if (GetGenericParameterEffectiveMemberTypes (genericParameter) != DynamicallyAccessedMemberTypes.None) {
@@ -1268,10 +1270,11 @@ namespace ILLink.Shared.TrimAnalysis
 			// - NeedsNew<SpecificType> - MarkStep will simply mark the default .ctor of SpecificType in this case, it has nothing to do with reflection
 			// - NeedsNew<TOuter> - this should be validated by the compiler/IL - TOuter must have matching constraints by definition, so nothing to validate
 			// - typeof(NeedsNew<>).MakeGenericType(typeOuter) - for this case we have to do it by hand as it's reflection. This is where this method helps.
-			static DynamicallyAccessedMemberTypes GetGenericParameterEffectiveMemberTypes (GenericParameterValue genericParameter)
+			DynamicallyAccessedMemberTypes GetGenericParameterEffectiveMemberTypes (GenericParameterValue genericParameter)
 			{
 				DynamicallyAccessedMemberTypes result = genericParameter.DynamicallyAccessedMemberTypes;
-				if (genericParameter.GenericParameter.HasDefaultConstructorConstraint ())
+				if (genericParameter.GenericParameter.HasDefaultConstructorConstraint () &&
+					warnVersion > WarnVersion.ILLink5)
 					result |= DynamicallyAccessedMemberTypes.PublicParameterlessConstructor;
 
 				return result;

--- a/src/ILLink.Shared/WarnVersion.cs
+++ b/src/ILLink.Shared/WarnVersion.cs
@@ -1,7 +1,7 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-namespace Mono.Linker
+namespace ILLink.Shared
 {
 	public enum WarnVersion
 	{

--- a/src/linker/Linker.Dataflow/HandleCallAction.cs
+++ b/src/linker/Linker.Dataflow/HandleCallAction.cs
@@ -30,6 +30,7 @@ namespace ILLink.Shared.TrimAnalysis
 			_callingMethodDefinition = callingMethodDefinition;
 			_annotations = context.Annotations.FlowAnnotations;
 			_requireDynamicallyAccessedMembersAction = new (reflectionMarker, diagnosticContext, _context);
+			_warnVersion = context.WarnVersion;
 		}
 
 		private partial bool MethodIsTypeConstructor (MethodProxy method)


### PR DESCRIPTION
In dotnet 6.0 we did not consider the struct constraint to imply the new() constraint, and this led to a few extra warnings in the dotnet 7 linker.

I'm not sure where the best place to put this change is, but here isolates the differences. Let me know if I should target dotnet/linker main or something else.
